### PR TITLE
Make "guilds.join" an option

### DIFF
--- a/Routes/discord.js
+++ b/Routes/discord.js
@@ -1,5 +1,4 @@
 const router = require('express').Router();
-const scopes = ["identify", "guilds", "guilds.join"];
 const fetch = require('node-fetch');
 const DBDStats = require('../ExternalStatistics/index');
 
@@ -7,6 +6,7 @@ const DiscordOauth2 = require("discord-oauth2");
 const oauth = new DiscordOauth2();
 
 module.exports = (app, config, themeConfig) => {
+    const scopes = config.guildAfterAuthorization?.use ? ["identify", "guilds", "guilds.join"] : ["identify", "guilds"];
     const RL = require('express-rate-limit');
     const RateLimits = config.rateLimits || {};
     let RateFunctions = {};


### PR DESCRIPTION
If the user enables guildAfterAuthorization, then it will enable the join guilds intent, otherwise it'll proceed without it.

Super handy for those who do not wish to grant those permissions for their bot.